### PR TITLE
Fixed an issue that causes build to fail on case-sensitive systems.

### DIFF
--- a/@types/phaser/index.d.ts
+++ b/@types/phaser/index.d.ts
@@ -1,3 +1,3 @@
-//// <reference path="../../node_modules/phaser/types/SpineFile.d.ts" />
+/// <reference path="../../node_modules/phaser/types/SpineFile.d.ts" />
 /// <reference path="../../node_modules/phaser/types/SpineGameObject.d.ts" />
 /// <reference path="../../node_modules/phaser/types/SpinePlugin.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
 			"node_module/phaser/types"
 		],
 		"types": [
-			"Phaser"
+			"phaser"
 		]
 	},
 	"include": [


### PR DESCRIPTION
I had an issue where the sample code wouldn't compile on a case-sensitive linux system. It turns our the value "Phaser" in the "types" property in `tsconfig.json` must match the case in the `@types/phaser/` folder. There was also an extra slash in the triple slash directive.